### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kluth/project-worker/security/code-scanning/1](https://github.com/kluth/project-worker/security/code-scanning/1)

The fix is to add an explicit `permissions:` block to the workflow to minimize the GITHUB_TOKEN capabilities granted to this job. Since none of the steps in the job modify repository contents, the minimal `contents: read` permission is sufficient and safest. You can add this block at the root of the workflow (just after the `name:` and before `on:`) to apply to all jobs, or at the job level (`build:`), but best practice is to set it at the top unless different jobs require different permissions. Only the `.github/workflows/ci.yml` file needs to be edited, and the block should be added after `name: CI`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
