### PR TITLE
feat(issue-7): Implement Kanban board management tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,12 @@ registerManageDependencies(server);
 registerManageSprints(server);
 registerGitTools(server);
 
+// Kanban Management (New Tools)
+import { registerSetWipLimit } from './tools/setWipLimit.js';
+import { registerGetBoardStatus } from './tools/getBoardStatus.js';
+registerSetWipLimit(server);
+registerGetBoardStatus(server);
+
 // Enterprise Features
 registerManageReleases(server);
 registerLogWork(server);

--- a/src/tools/getBoardStatus.ts
+++ b/src/tools/getBoardStatus.ts
@@ -1,0 +1,89 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { configManager } from '../config.js';
+import { ProviderFactory } from '../services/providerFactory.js';
+import { Task } from '../types.js';
+
+export function registerGetBoardStatus(server: McpServer) {
+  server.registerTool(
+    'get_board_status',
+    {
+      description: 'Displays the status of a Kanban board, including tasks per column and WIP limit violations.',
+      inputSchema: z.object({
+        boardName: z.string().optional().describe('The name of the Kanban board. Defaults to "Default Board" if omitted.'),
+      }).shape,
+    },
+    async ({ boardName = 'Default Board' }) => {
+      const config = await configManager.get();
+      const kanbanBoard = config.kanbanBoards.find(b => b.boardName === boardName);
+
+      if (!kanbanBoard) {
+        return { isError: true, content: [{ type: 'text', text: `Kanban board "${boardName}" not found.` }] };
+      }
+
+      const provider = await ProviderFactory.getProvider(config.activeProvider);
+      const allTasks = await provider.getTasks(); // Fetch all tasks from active provider
+
+      const statusMap = new Map<string, Task[]>();
+      for (const task of allTasks) {
+        const statusKey = task.status.toLowerCase(); // Use lowercase for consistent grouping
+        if (!statusMap.has(statusKey)) {
+          statusMap.set(statusKey, []);
+        }
+        statusMap.get(statusKey)?.push(task);
+      }
+
+      let output = `Kanban Board: ${boardName}\n\n`;
+      let hasViolations = false;
+
+      // Sort statuses for consistent output, prioritize those with WIP limits
+      const sortedStatuses = Object.keys(kanbanBoard.wipLimits)
+        .sort((a, b) => {
+          const limitA = kanbanBoard.wipLimits[a as TaskStatus];
+          const limitB = kanbanBoard.wipLimits[b as TaskStatus];
+          if (limitA !== undefined && limitB === undefined) return -1;
+          if (limitA === undefined && limitB !== undefined) return 1;
+          return a.localeCompare(b);
+        });
+
+      const otherStatuses = Array.from(statusMap.keys())
+        .filter(s => !Object.keys(kanbanBoard.wipLimits).includes(s))
+        .sort();
+
+      for (const status of [...sortedStatuses, ...otherStatuses]) {
+        const tasksInStatus = statusMap.get(status) || [];
+        const limit = kanbanBoard.wipLimits[status as TaskStatus];
+        const currentCount = tasksInStatus.length;
+        
+        let statusLine = `Status: ${status} (Tasks: ${currentCount}`;
+        if (limit !== undefined) {
+          statusLine += `, WIP Limit: ${limit}`;
+          if (limit > 0 && currentCount > limit) {
+            statusLine += ` - ***VIOLATION***`;
+            hasViolations = true;
+          }
+        }
+        statusLine += `)\n`;
+        output += statusLine;
+
+        for (const task of tasksInStatus) {
+          output += `  - ${task.id}: ${task.title}\n`;
+        }
+        output += `\n`;
+      }
+      
+      if (hasViolations) {
+        output += `***WARNING: One or more WIP limits have been violated!***\n`;
+      }
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: output
+          }
+        ]
+      };
+    },
+  );
+}

--- a/src/tools/setWipLimit.ts
+++ b/src/tools/setWipLimit.ts
@@ -1,0 +1,39 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { configManager } from '../config.js';
+import { TaskStatus } from '../types.js';
+
+export function registerSetWipLimit(server: McpServer) {
+  server.registerTool(
+    'set_wip_limit',
+    {
+      description: 'Sets or updates a Work-In-Progress (WIP) limit for a specific status/column on a Kanban board.',
+      inputSchema: z.object({
+        boardName: z.string().optional().describe('The name of the Kanban board. Defaults to "Default Board" if omitted.'),
+        status: z.string().describe('The status/column for which to set the WIP limit.'),
+        limit: z.number().int().positive().or(z.literal(0)).describe('The maximum number of tasks allowed in this status. Use 0 for no limit.'),
+      }).shape,
+    },
+    async ({ boardName = 'Default Board', status, limit }) => {
+      const config = await configManager.get();
+      let kanbanBoard = config.kanbanBoards.find(b => b.boardName === boardName);
+
+      if (!kanbanBoard) {
+        kanbanBoard = { boardName, wipLimits: {} };
+        config.kanbanBoards.push(kanbanBoard);
+      }
+
+      kanbanBoard.wipLimits[status as TaskStatus] = limit;
+      await configManager.save(config);
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `WIP limit for status "${status}" on board "${boardName}" set to ${limit}.`
+          }
+        ]
+      };
+    },
+  );
+}

--- a/tests/tools/kanbanManagement.test.ts
+++ b/tests/tools/kanbanManagement.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerSetWipLimit } from '../../src/tools/setWipLimit.js';
+import { registerGetBoardStatus } from '../../src/tools/getBoardStatus.js';
+import { configManager, AppConfig, KanbanBoardConfig } from '../../src/config.js';
+import { ProviderFactory } from '../../src/services/providerFactory.js';
+import { Task } from '../../src/types.js';
+
+// Mock configManager
+vi.mock('../../src/config.js', () => ({
+  configManager: {
+    get: vi.fn(),
+    save: vi.fn(),
+  },
+}));
+
+// Mock ProviderFactory and Provider
+const mockProvider = {
+  getTasks: vi.fn(),
+  // Add other provider methods if needed by these tools
+};
+
+vi.mock('../../src/services/providerFactory.js', () => ({
+  ProviderFactory: {
+    getProvider: vi.fn(() => mockProvider),
+  },
+}));
+
+describe('Kanban Management Tools', () => {
+  let mockServer: McpServer;
+  let mockConfig: AppConfig;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockServer = { registerTool: vi.fn() } as unknown as McpServer;
+
+    mockConfig = {
+      activeProvider: 'local',
+      providers: [],
+      agileMethodology: { type: 'kanban', settings: {} },
+      sprints: [],
+      kanbanBoards: [],
+    };
+    (configManager.get as vi.Mock).mockResolvedValue(mockConfig);
+    (configManager.save as vi.Mock).mockImplementation(async (newConfig: AppConfig) => {
+      mockConfig = newConfig; // Update mockConfig state
+    });
+    mockProvider.getTasks.mockResolvedValue([]); // Default empty tasks
+  });
+
+  describe('set_wip_limit', () => {
+    it('should register the set_wip_limit tool', () => {
+      registerSetWipLimit(mockServer);
+      expect(mockServer.registerTool).toHaveBeenCalledWith(
+        'set_wip_limit',
+        expect.any(Object),
+        expect.any(Function)
+      );
+    });
+
+    it('should set a WIP limit for a status on a new board', async () => {
+      registerSetWipLimit(mockServer);
+      const handler = (mockServer.registerTool as any).mock.calls.find((c: any) => c[0] === 'set_wip_limit')[2];
+
+      const boardName = 'My Kanban';
+      const status = 'in progress';
+      const limit = 3;
+
+      const result = await handler({ boardName, status, limit });
+
+      expect(configManager.get).toHaveBeenCalled();
+      expect(configManager.save).toHaveBeenCalledWith(expect.objectContaining({
+        kanbanBoards: expect.arrayContaining([
+          expect.objectContaining({
+            boardName: boardName,
+            wipLimits: { [status]: limit },
+          })
+        ])
+      }));
+      expect(result.content[0].text).toContain(`WIP limit for status "${status}" on board "${boardName}" set to ${limit}.`);
+      expect(mockConfig.kanbanBoards).toHaveLength(1);
+      expect(mockConfig.kanbanBoards[0].wipLimits[status]).toBe(limit);
+    });
+
+    it('should update a WIP limit for an existing status on an existing board', async () => {
+      const existingBoard: KanbanBoardConfig = {
+        boardName: 'My Kanban',
+        wipLimits: { 'in progress': 2, 'todo': 5 },
+      };
+      mockConfig.kanbanBoards.push(existingBoard);
+      (configManager.get as vi.Mock).mockResolvedValueOnce(mockConfig);
+
+      registerSetWipLimit(mockServer);
+      const handler = (mockServer.registerTool as any).mock.calls.find((c: any) => c[0] === 'set_wip_limit')[2];
+
+      const boardName = 'My Kanban';
+      const status = 'in progress';
+      const newLimit = 4;
+
+      const result = await handler({ boardName, status, limit: newLimit });
+
+      expect(configManager.get).toHaveBeenCalled();
+      expect(configManager.save).toHaveBeenCalledWith(expect.objectContaining({
+        kanbanBoards: expect.arrayContaining([
+          expect.objectContaining({
+            boardName: boardName,
+            wipLimits: { 'in progress': newLimit, 'todo': 5 },
+          })
+        ])
+      }));
+      expect(result.content[0].text).toContain(`WIP limit for status "${status}" on board "${boardName}" set to ${newLimit}.`);
+      expect(mockConfig.kanbanBoards).toHaveLength(1);
+      expect(mockConfig.kanbanBoards[0].wipLimits[status]).toBe(newLimit);
+    });
+  });
+
+  describe('get_board_status', () => {
+    it('should register the get_board_status tool', () => {
+      registerGetBoardStatus(mockServer);
+      expect(mockServer.registerTool).toHaveBeenCalledWith(
+        'get_board_status',
+        expect.any(Object),
+        expect.any(Function)
+      );
+    });
+
+    it('should return an error if the board is not found', async () => {
+      registerGetBoardStatus(mockServer);
+      const handler = (mockServer.registerTool as any).mock.calls.find((c: any) => c[0] === 'get_board_status')[2];
+
+      const result = await handler({ boardName: 'NonExistent' });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Kanban board "NonExistent" not found.');
+    });
+
+    it('should display board status with tasks grouped by status', async () => {
+      const existingBoard: KanbanBoardConfig = {
+        boardName: 'Default Board',
+        wipLimits: { 'in progress': 2 },
+      };
+      mockConfig.kanbanBoards.push(existingBoard);
+      (configManager.get as vi.Mock).mockResolvedValueOnce(mockConfig);
+
+      const tasks: Task[] = [
+        { id: '1', title: 'Task A', status: 'to do', description: '', priority: 'medium', type: 'task', tags: [], comments: [], createdAt: '', updatedAt: '' },
+        { id: '2', title: 'Task B', status: 'in progress', description: '', priority: 'medium', type: 'task', tags: [], comments: [], createdAt: '', updatedAt: '' },
+        { id: '3', title: 'Task C', status: 'in progress', description: '', priority: 'medium', type: 'task', tags: [], comments: [], createdAt: '', updatedAt: '' },
+        { id: '4', title: 'Task D', status: 'done', description: '', priority: 'medium', type: 'task', tags: [], comments: [], createdAt: '', updatedAt: '' },
+      ];
+      mockProvider.getTasks.mockResolvedValue(tasks);
+
+      registerGetBoardStatus(mockServer);
+      const handler = (mockServer.registerTool as any).mock.calls.find((c: any) => c[0] === 'get_board_status')[2];
+
+      const result = await handler({});
+
+      expect(result.content[0].text).toContain('Kanban Board: Default Board');
+      expect(result.content[0].text).toContain('Status: in progress (Tasks: 2, WIP Limit: 2)');
+      expect(result.content[0].text).toContain('Status: to do (Tasks: 1)');
+      expect(result.content[0].text).toContain('Status: done (Tasks: 1)');
+      expect(result.content[0].text).toContain('  - 2: Task B');
+      expect(result.content[0].text).not.toContain('***VIOLATION***');
+    });
+
+    it('should highlight WIP limit violations', async () => {
+      const existingBoard: KanbanBoardConfig = {
+        boardName: 'Default Board',
+        wipLimits: { 'in progress': 1 },
+      };
+      mockConfig.kanbanBoards.push(existingBoard);
+      (configManager.get as vi.Mock).mockResolvedValueOnce(mockConfig);
+
+      const tasks: Task[] = [
+        { id: '1', title: 'Task A', status: 'in progress', description: '', priority: 'medium', type: 'task', tags: [], comments: [], createdAt: '', updatedAt: '' },
+        { id: '2', title: 'Task B', status: 'in progress', description: '', priority: 'medium', type: 'task', tags: [], comments: [], createdAt: '', updatedAt: '' },
+      ];
+      mockProvider.getTasks.mockResolvedValue(tasks);
+
+      registerGetBoardStatus(mockServer);
+      const handler = (mockServer.registerTool as any).mock.calls.find((c: any) => c[0] === 'get_board_status')[2];
+
+      const result = await handler({});
+
+      expect(result.content[0].text).toContain('Status: in progress (Tasks: 2, WIP Limit: 1 - ***VIOLATION***)');
+      expect(result.content[0].text).toContain('***WARNING: One or more WIP limits have been violated!***');
+    });
+
+    it('should handle statuses with 0 limit (no limit)', async () => {
+      const existingBoard: KanbanBoardConfig = {
+        boardName: 'Default Board',
+        wipLimits: { 'in progress': 0 },
+      };
+      mockConfig.kanbanBoards.push(existingBoard);
+      (configManager.get as vi.Mock).mockResolvedValueOnce(mockConfig);
+
+      const tasks: Task[] = [
+        { id: '1', title: 'Task A', status: 'in progress', description: '', priority: 'medium', type: 'task', tags: [], comments: [], createdAt: '', updatedAt: '' },
+        { id: '2', title: 'Task B', status: 'in progress', description: '', priority: 'medium', type: 'task', tags: [], comments: [], createdAt: '', updatedAt: '' },
+        { id: '3', title: 'Task C', status: 'in progress', description: '', priority: 'medium', type: 'task', tags: [], comments: [], createdAt: '', updatedAt: '' },
+      ];
+      mockProvider.getTasks.mockResolvedValue(tasks);
+
+      registerGetBoardStatus(mockServer);
+      const handler = (mockServer.registerTool as any).mock.calls.find((c: any) => c[0] === 'get_board_status')[2];
+
+      const result = await handler({});
+
+      expect(result.content[0].text).toContain('Status: in progress (Tasks: 3, WIP Limit: 0)');
+      expect(result.content[0].text).not.toContain('***VIOLATION***');
+    });
+  });
+});


### PR DESCRIPTION
Implements tools to set WIP limits and display Kanban board status, including highlighting violations. Integrates with existing task providers and stores Kanban board configurations in app config.\n\nCloses #7