### PR TITLE
feat(prince2): Implement PRINCE2 methodology support (Issue #13)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,9 @@ import type {
   ValueStream,
   WasteItem,
   PdcaCycle,
+  ProjectBrief,
+  BusinessCase,
+  Prince2Organization,
 } from './types.js'; // Import agile methodology types
 
 const CONFIG_DIR = path.join(os.homedir(), '.gemini-project-worker');
@@ -42,6 +45,9 @@ export interface AppConfig {
   valueStreams: ValueStream[]; // From Issue #12
   wasteLog: WasteItem[]; // From Issue #12
   pdcaCycles: PdcaCycle[]; // From Issue #12
+  projectBrief?: ProjectBrief; // From Issue #13
+  businessCase?: BusinessCase; // From Issue #13
+  prince2Organization?: Prince2Organization; // From Issue #13
 }
 
 const DEFAULT_CONFIG: AppConfig = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,14 @@ registerDefineValueStream(server);
 registerTrackWaste(server);
 registerManagePdcaCycle(server);
 
+// PRINCE2 Methodology Management (Issue #13)
+import { registerDefineProjectBrief } from './tools/defineProjectBrief.js';
+import { registerManageBusinessCase } from './tools/manageBusinessCase.js';
+import { registerDefinePrince2Organization } from './tools/definePrince2Organization.js';
+registerDefineProjectBrief(server);
+registerManageBusinessCase(server);
+registerDefinePrince2Organization(server);
+
 // Enterprise Features
 registerManageReleases(server);
 registerLogWork(server);

--- a/src/tools/definePrince2Organization.ts
+++ b/src/tools/definePrince2Organization.ts
@@ -1,0 +1,83 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { configManager } from '../config.js';
+import type { Prince2Organization } from '../types.js';
+
+export function registerDefinePrince2Organization(server: McpServer): void {
+  server.registerTool(
+    'define_prince2_organization',
+    {
+      description:
+        'Define or update the PRINCE2 project organization structure with key roles and responsibilities.',
+      inputSchema: z.object({
+        executiveBoardMember: z
+          .string()
+          .describe('Executive/Board member (ultimate decision maker)'),
+        projectManager: z.string().describe('Project Manager'),
+        teamManager: z.string().describe('Team Manager'),
+        seniorUser: z.string().optional().describe('Senior User representative'),
+        seniorSupplier: z.string().optional().describe('Senior Supplier representative'),
+        projectAssurance: z.string().optional().describe('Project Assurance role'),
+        changeAuthority: z.string().optional().describe('Change Authority'),
+      }).shape,
+    },
+    async ({
+      executiveBoardMember,
+      projectManager,
+      teamManager,
+      seniorUser,
+      seniorSupplier,
+      projectAssurance,
+      changeAuthority,
+    }) => {
+      const config = await configManager.get();
+
+      // Validate PRINCE2 methodology is active
+      if (config.agileMethodology.type !== 'prince2') {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Error: PRINCE2 methodology must be active to define organization structure. Use manage_agile_config to set methodology to prince2.',
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const isUpdate = !!config.prince2Organization;
+
+      // Create or update organization structure
+      const organization: Prince2Organization = {
+        executiveBoardMember,
+        projectManager,
+        teamManager,
+        seniorUser,
+        seniorSupplier,
+        projectAssurance,
+        changeAuthority,
+        createdAt: config.prince2Organization?.createdAt || new Date().toISOString(),
+        updatedAt: isUpdate ? new Date().toISOString() : undefined,
+      };
+
+      config.prince2Organization = organization;
+      await configManager.save(config);
+
+      const roleCount =
+        3 +
+        (seniorUser ? 1 : 0) +
+        (seniorSupplier ? 1 : 0) +
+        (projectAssurance ? 1 : 0) +
+        (changeAuthority ? 1 : 0);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Organization structure ${isUpdate ? 'updated' : 'defined'} successfully.\nExecutive: ${executiveBoardMember}\nProject Manager: ${projectManager}\nTeam Manager: ${teamManager}\nTotal roles defined: ${roleCount}`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/defineProjectBrief.ts
+++ b/src/tools/defineProjectBrief.ts
@@ -1,0 +1,64 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { configManager } from '../config.js';
+import type { ProjectBrief } from '../types.js';
+
+export function registerDefineProjectBrief(server: McpServer): void {
+  server.registerTool(
+    'define_project_brief',
+    {
+      description:
+        'Define or update the PRINCE2 Project Brief outlining project background, objectives, deliverables, and scope.',
+      inputSchema: z.object({
+        background: z.string().describe('Project background and context'),
+        objectives: z.array(z.string()).describe('Project objectives'),
+        deliverables: z.array(z.string()).optional().describe('Expected deliverables'),
+        scope: z.string().optional().describe('Project scope definition'),
+        constraints: z.array(z.string()).optional().describe('Project constraints'),
+        assumptions: z.array(z.string()).optional().describe('Project assumptions'),
+      }).shape,
+    },
+    async ({ background, objectives, deliverables, scope, constraints, assumptions }) => {
+      const config = await configManager.get();
+
+      // Validate PRINCE2 methodology is active
+      if (config.agileMethodology.type !== 'prince2') {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Error: PRINCE2 methodology must be active to define project brief. Use manage_agile_config to set methodology to prince2.',
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const isUpdate = !!config.projectBrief;
+
+      // Create or update project brief
+      const projectBrief: ProjectBrief = {
+        background,
+        objectives,
+        deliverables: deliverables || [],
+        scope,
+        constraints,
+        assumptions,
+        createdAt: config.projectBrief?.createdAt || new Date().toISOString(),
+        updatedAt: isUpdate ? new Date().toISOString() : undefined,
+      };
+
+      config.projectBrief = projectBrief;
+      await configManager.save(config);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Project brief ${isUpdate ? 'updated' : 'defined'} successfully.\nObjectives: ${objectives.length}\nDeliverables: ${deliverables?.length || 0}${scope ? '\nScope: Defined' : ''}`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/manageBusinessCase.ts
+++ b/src/tools/manageBusinessCase.ts
@@ -1,0 +1,161 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { configManager } from '../config.js';
+import type { BusinessCase } from '../types.js';
+
+export function registerManageBusinessCase(server: McpServer): void {
+  server.registerTool(
+    'manage_business_case',
+    {
+      description:
+        'Create, update, or retrieve the PRINCE2 Business Case which justifies the project investment.',
+      inputSchema: z.object({
+        action: z
+          .enum(['create', 'update', 'get'])
+          .describe('Action: create new, update existing, or get current business case'),
+        executiveSummary: z
+          .string()
+          .optional()
+          .describe('Executive summary of the business case'),
+        reasons: z.array(z.string()).optional().describe('Reasons for undertaking the project'),
+        benefits: z.array(z.string()).optional().describe('Expected benefits'),
+        costs: z.number().optional().describe('Estimated costs'),
+        timescale: z.string().optional().describe('Project timescale'),
+        risks: z.array(z.string()).optional().describe('Major risks'),
+        options: z.array(z.string()).optional().describe('Options considered'),
+      }).shape,
+    },
+    async ({
+      action,
+      executiveSummary,
+      reasons,
+      benefits,
+      costs,
+      timescale,
+      risks,
+      options,
+    }) => {
+      const config = await configManager.get();
+
+      // Validate PRINCE2 methodology is active
+      if (config.agileMethodology.type !== 'prince2') {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Error: PRINCE2 methodology must be active to manage business case. Use manage_agile_config to set methodology to prince2.',
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      if (action === 'get') {
+        if (!config.businessCase) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'No business case defined. Use action "create" to define one.',
+              },
+            ],
+          };
+        }
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(config.businessCase, null, 2),
+            },
+          ],
+        };
+      }
+
+      if (action === 'create') {
+        if (!executiveSummary) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: executiveSummary is required for create action.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const newBusinessCase: BusinessCase = {
+          executiveSummary,
+          reasons: reasons || [],
+          benefits: benefits || [],
+          costs: costs || 0,
+          timescale: timescale || '',
+          risks: risks || [],
+          options: options || [],
+          createdAt: new Date().toISOString(),
+        };
+
+        config.businessCase = newBusinessCase;
+        await configManager.save(config);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Business case created successfully.\nBenefits: ${benefits?.length || 0}\nCosts: ${costs || 0}\nTimescale: ${timescale || 'Not specified'}`,
+            },
+          ],
+        };
+      }
+
+      if (action === 'update') {
+        if (!config.businessCase) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: No business case exists. Use action "create" first.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        // Update only provided fields
+        const updatedBusinessCase: BusinessCase = {
+          ...config.businessCase,
+          executiveSummary: executiveSummary || config.businessCase.executiveSummary,
+          reasons: reasons || config.businessCase.reasons,
+          benefits: benefits || config.businessCase.benefits,
+          costs: costs !== undefined ? costs : config.businessCase.costs,
+          timescale: timescale || config.businessCase.timescale,
+          risks: risks || config.businessCase.risks,
+          options: options || config.businessCase.options,
+          updatedAt: new Date().toISOString(),
+        };
+
+        config.businessCase = updatedBusinessCase;
+        await configManager.save(config);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Business case updated successfully.',
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Error: Invalid action specified.',
+          },
+        ],
+        isError: true,
+      };
+    },
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -267,3 +267,39 @@ export interface PdcaCycle {
   createdAt: string;
   completedAt?: string;
 }
+
+// PRINCE2 methodology types
+export interface ProjectBrief {
+  background: string; // Project background and context
+  objectives: string[]; // Project objectives
+  deliverables: string[]; // Expected deliverables
+  scope?: string; // Project scope
+  constraints?: string[]; // Project constraints
+  assumptions?: string[]; // Project assumptions
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface BusinessCase {
+  executiveSummary: string;
+  reasons: string[]; // Reasons for the project
+  benefits: string[]; // Expected benefits
+  costs: number; // Estimated costs
+  timescale: string; // Project timescale
+  risks?: string[]; // Major risks
+  options?: string[]; // Options considered
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface Prince2Organization {
+  executiveBoardMember: string; // Executive (ultimate decision maker)
+  projectManager: string; // Project Manager
+  teamManager: string; // Team Manager
+  seniorUser?: string; // Senior User
+  seniorSupplier?: string; // Senior Supplier
+  projectAssurance?: string; // Project Assurance role
+  changeAuthority?: string; // Change Authority
+  createdAt: string;
+  updatedAt?: string;
+}

--- a/tests/tools/prince2Management.test.ts
+++ b/tests/tools/prince2Management.test.ts
@@ -1,0 +1,267 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerDefineProjectBrief } from '../../src/tools/defineProjectBrief.js';
+import { registerManageBusinessCase } from '../../src/tools/manageBusinessCase.js';
+import { registerDefinePrince2Organization } from '../../src/tools/definePrince2Organization.js';
+import type { AppConfig } from '../../src/config.js';
+import { configManager } from '../../src/config.js';
+
+// Mock configManager
+vi.mock('../../src/config.js', () => ({
+  configManager: {
+    get: vi.fn(),
+    save: vi.fn(),
+  },
+}));
+
+describe('PRINCE2 Methodology Management', () => {
+  let mockServer: McpServer;
+  let mockConfig: AppConfig;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockServer = { registerTool: vi.fn() } as unknown as McpServer;
+
+    mockConfig = {
+      activeProvider: 'local',
+      providers: [],
+      agileMethodology: { type: 'prince2', settings: {} },
+      sprints: [],
+      kanbanBoards: [],
+      events: [],
+      waterfallPhases: [],
+      valueStreams: [],
+      wasteLog: [],
+      pdcaCycles: [],
+      projectBrief: undefined,
+      businessCase: undefined,
+      prince2Organization: undefined,
+    } as AppConfig;
+
+    (configManager.get as vi.Mock).mockResolvedValue(mockConfig);
+  });
+
+  describe('define_project_brief', () => {
+    it('should register the define_project_brief tool', () => {
+      registerDefineProjectBrief(mockServer);
+      expect(mockServer.registerTool).toHaveBeenCalledWith(
+        'define_project_brief',
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should define a project brief', async () => {
+      registerDefineProjectBrief(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        background: 'Project to modernize legacy system',
+        objectives: ['Reduce technical debt', 'Improve performance'],
+        deliverables: ['New architecture design', 'Migration plan'],
+        scope: 'Backend services only',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Project brief defined');
+    });
+
+    it('should require PRINCE2 methodology to be active', async () => {
+      mockConfig.agileMethodology.type = 'scrum';
+      registerDefineProjectBrief(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        background: 'Test',
+        objectives: ['Objective 1'],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('PRINCE2 methodology must be active');
+    });
+
+    it('should update existing project brief', async () => {
+      mockConfig.projectBrief = {
+        background: 'Old background',
+        objectives: ['Old objective'],
+        deliverables: [],
+        createdAt: new Date().toISOString(),
+      };
+      registerDefineProjectBrief(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        background: 'Updated background',
+        objectives: ['Updated objective'],
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.content[0].text).toContain('updated');
+    });
+  });
+
+  describe('manage_business_case', () => {
+    it('should register the manage_business_case tool', () => {
+      registerManageBusinessCase(mockServer);
+      expect(mockServer.registerTool).toHaveBeenCalledWith(
+        'manage_business_case',
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should create a business case', async () => {
+      registerManageBusinessCase(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        action: 'create',
+        executiveSummary: 'This project will deliver value',
+        reasons: ['Reason 1', 'Reason 2'],
+        benefits: ['Benefit 1', 'Benefit 2'],
+        costs: 100000,
+        timescale: '6 months',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Business case created');
+    });
+
+    it('should require PRINCE2 methodology to be active', async () => {
+      mockConfig.agileMethodology.type = 'kanban';
+      registerManageBusinessCase(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        action: 'create',
+        executiveSummary: 'Test',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('PRINCE2 methodology must be active');
+    });
+
+    it('should get business case details', async () => {
+      mockConfig.businessCase = {
+        executiveSummary: 'Summary',
+        reasons: ['Reason'],
+        benefits: ['Benefit'],
+        costs: 50000,
+        timescale: '3 months',
+        risks: [],
+        createdAt: new Date().toISOString(),
+      };
+      registerManageBusinessCase(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        action: 'get',
+      });
+
+      expect(result.content[0].text).toContain('Summary');
+    });
+
+    it('should update business case', async () => {
+      mockConfig.businessCase = {
+        executiveSummary: 'Original summary',
+        reasons: [],
+        benefits: [],
+        costs: 0,
+        timescale: '',
+        risks: [],
+        createdAt: new Date().toISOString(),
+      };
+      registerManageBusinessCase(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        action: 'update',
+        executiveSummary: 'Updated summary',
+        costs: 75000,
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.content[0].text).toContain('updated');
+    });
+  });
+
+  describe('define_prince2_organization', () => {
+    it('should register the define_prince2_organization tool', () => {
+      registerDefinePrince2Organization(mockServer);
+      expect(mockServer.registerTool).toHaveBeenCalledWith(
+        'define_prince2_organization',
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should define PRINCE2 organization structure', async () => {
+      registerDefinePrince2Organization(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        executiveBoardMember: 'John Doe',
+        projectManager: 'Jane Smith',
+        teamManager: 'Bob Johnson',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Organization structure defined');
+    });
+
+    it('should require PRINCE2 methodology to be active', async () => {
+      mockConfig.agileMethodology.type = 'lean';
+      registerDefinePrince2Organization(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        executiveBoardMember: 'John',
+        projectManager: 'Jane',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('PRINCE2 methodology must be active');
+    });
+
+    it('should include optional roles', async () => {
+      registerDefinePrince2Organization(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        executiveBoardMember: 'John Doe',
+        projectManager: 'Jane Smith',
+        teamManager: 'Bob Johnson',
+        seniorSupplier: 'Alice Brown',
+        seniorUser: 'Charlie White',
+        projectAssurance: 'Diana Green',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.content[0].text).toContain('Organization structure defined');
+    });
+
+    it('should update existing organization structure', async () => {
+      mockConfig.prince2Organization = {
+        executiveBoardMember: 'Old Executive',
+        projectManager: 'Old PM',
+        teamManager: 'Old TM',
+        createdAt: new Date().toISOString(),
+      };
+      registerDefinePrince2Organization(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        executiveBoardMember: 'New Executive',
+        projectManager: 'New PM',
+        teamManager: 'New TM',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.content[0].text).toContain('updated');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements PRINCE2 project management methodology with key artifacts and organization structure
- Adds three new MCP tools: `define_project_brief`, `manage_business_case`, and `define_prince2_organization`
- Includes comprehensive TDD test suite with 14 tests (100% coverage for 2 of 3 tools)

## Changes
- **New Types**: `ProjectBrief`, `BusinessCase`, `Prince2Organization` with full type safety
- **Tool: define_project_brief**: Define or update project background, objectives, deliverables, and scope
- **Tool: manage_business_case**: Create, update, or retrieve business case with executive summary, benefits, costs, risks
- **Tool: define_prince2_organization**: Define PRINCE2 roles (Executive, Project Manager, Team Manager, Senior User/Supplier, etc.)
- **Config**: Added optional `projectBrief`, `businessCase`, and `prince2Organization` to AppConfig
- **Tests**: Full TDD coverage with methodology validation and update scenarios

## Test Plan
- [x] All 118 tests pass (14 new PRINCE2 tests)
- [x] TypeScript compilation successful  
- [x] Coverage: defineProjectBrief 100%, definePrince2Organization 100%, manageBusinessCase 82.6%
- [x] Validates methodology requirement (must be prince2)
- [x] Supports create/update actions for Project Brief and Organization
- [x] Business Case with create/update/get actions
- [x] Prevents operations without PRINCE2 methodology active

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)