### PR TITLE
feat(retrospective): Implement retrospective & feedback tools (Issue #15)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,8 @@ import type {
   ProjectBrief,
   BusinessCase,
   Prince2Organization,
+  Retrospective,
+  RetroAction,
 } from './types.js'; // Import agile methodology types
 
 const CONFIG_DIR = path.join(os.homedir(), '.gemini-project-worker');
@@ -48,6 +50,8 @@ export interface AppConfig {
   projectBrief?: ProjectBrief; // From Issue #13
   businessCase?: BusinessCase; // From Issue #13
   prince2Organization?: Prince2Organization; // From Issue #13
+  retrospectives: Retrospective[]; // From Issue #15
+  retroActions: RetroAction[]; // From Issue #15
 }
 
 const DEFAULT_CONFIG: AppConfig = {
@@ -65,6 +69,8 @@ const DEFAULT_CONFIG: AppConfig = {
   valueStreams: [], // Default for value streams
   wasteLog: [], // Default for waste log
   pdcaCycles: [], // Default for PDCA cycles
+  retrospectives: [], // Default for retrospectives
+  retroActions: [], // Default for retro actions
 };
 
 export class ConfigManager {
@@ -95,6 +101,8 @@ export class ConfigManager {
       parsedConfig.valueStreams = parsedConfig.valueStreams || DEFAULT_CONFIG.valueStreams;
       parsedConfig.wasteLog = parsedConfig.wasteLog || DEFAULT_CONFIG.wasteLog;
       parsedConfig.pdcaCycles = parsedConfig.pdcaCycles || DEFAULT_CONFIG.pdcaCycles;
+      parsedConfig.retrospectives = parsedConfig.retrospectives || DEFAULT_CONFIG.retrospectives;
+      parsedConfig.retroActions = parsedConfig.retroActions || DEFAULT_CONFIG.retroActions;
       this.config = parsedConfig; // Assign to this.config after ensuring it's fully initialized
       return parsedConfig;
     } catch (e: unknown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,14 @@ registerDefineProjectBrief(server);
 registerManageBusinessCase(server);
 registerDefinePrince2Organization(server);
 
+// Retrospective & Feedback Tools (Issue #15)
+import { registerStartRetrospective } from './tools/startRetrospective.js';
+import { registerSubmitFeedback } from './tools/submitFeedback.js';
+import { registerTrackRetroActions } from './tools/trackRetroActions.js';
+registerStartRetrospective(server);
+registerSubmitFeedback(server);
+registerTrackRetroActions(server);
+
 // Enterprise Features
 registerManageReleases(server);
 registerLogWork(server);

--- a/src/tools/startRetrospective.ts
+++ b/src/tools/startRetrospective.ts
@@ -1,0 +1,49 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { configManager } from '../config.js';
+import { randomUUID } from 'crypto';
+import type { Retrospective } from '../types.js';
+
+export function registerStartRetrospective(server: McpServer): void {
+  server.registerTool(
+    'start_retrospective',
+    {
+      description:
+        'Start a new team retrospective session with a chosen format (start-stop-continue, mad-sad-glad, 4Ls, sailboat).',
+      inputSchema: z.object({
+        title: z.string().describe('Title/name of the retrospective session'),
+        format: z
+          .enum(['start-stop-continue', 'mad-sad-glad', '4Ls', 'sailboat'])
+          .describe('Retrospective format to use'),
+        facilitator: z.string().optional().describe('Name of the session facilitator'),
+        participants: z.array(z.string()).optional().describe('List of participant names'),
+      }).shape,
+    },
+    async ({ title, format, facilitator, participants }) => {
+      const config = await configManager.get();
+
+      const newRetrospective: Retrospective = {
+        id: randomUUID(),
+        title,
+        format,
+        facilitator,
+        participants,
+        status: 'active',
+        feedback: [],
+        createdAt: new Date().toISOString(),
+      };
+
+      config.retrospectives.push(newRetrospective);
+      await configManager.save(config);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Retrospective started successfully.\nID: ${newRetrospective.id}\nTitle: ${title}\nFormat: ${format}${facilitator ? `\nFacilitator: ${facilitator}` : ''}${participants ? `\nParticipants: ${participants.length}` : ''}`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/submitFeedback.ts
+++ b/src/tools/submitFeedback.ts
@@ -1,0 +1,76 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { configManager } from '../config.js';
+import { randomUUID } from 'crypto';
+import type { FeedbackItem } from '../types.js';
+
+export function registerSubmitFeedback(server: McpServer): void {
+  server.registerTool(
+    'submit_feedback',
+    {
+      description:
+        'Submit feedback to an active retrospective session. Supports positive, negative, and suggestion feedback types.',
+      inputSchema: z.object({
+        retroId: z.string().describe('ID of the retrospective session'),
+        type: z
+          .enum(['positive', 'negative', 'suggestion'])
+          .describe('Type of feedback (positive, negative, or suggestion)'),
+        content: z.string().describe('Feedback content'),
+        author: z.string().optional().describe('Name of the person submitting feedback'),
+        anonymous: z
+          .boolean()
+          .optional()
+          .describe('Submit feedback anonymously (default: false)'),
+      }).shape,
+    },
+    async ({ retroId, type, content, author, anonymous }) => {
+      const config = await configManager.get();
+
+      const retrospective = config.retrospectives.find((r) => r.id === retroId);
+      if (!retrospective) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: Retrospective with ID ${retroId} not found.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      if (retrospective.status === 'closed') {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: 'Error: Cannot submit feedback to a closed retrospective.',
+            },
+          ],
+          isError: true,
+        };
+      }
+
+      const feedbackItem: FeedbackItem = {
+        id: randomUUID(),
+        type,
+        content,
+        author: anonymous ? undefined : author,
+        anonymous: anonymous || false,
+        createdAt: new Date().toISOString(),
+      };
+
+      retrospective.feedback.push(feedbackItem);
+      await configManager.save(config);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Feedback submitted successfully.\nType: ${type}\nID: ${feedbackItem.id}${anonymous ? '\n(Anonymous)' : author ? `\nAuthor: ${author}` : ''}`,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/trackRetroActions.ts
+++ b/src/tools/trackRetroActions.ts
@@ -1,0 +1,159 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { configManager } from '../config.js';
+import { randomUUID } from 'crypto';
+import type { RetroAction } from '../types.js';
+
+export function registerTrackRetroActions(server: McpServer): void {
+  server.registerTool(
+    'track_retro_actions',
+    {
+      description:
+        'Create, update, or list action items identified during retrospectives. Track progress on continuous improvement.',
+      inputSchema: z.object({
+        action: z
+          .enum(['create', 'update', 'list'])
+          .describe('Action: create new, update existing, or list action items'),
+        description: z.string().optional().describe('Action item description (for create)'),
+        assignee: z.string().optional().describe('Person assigned to the action (for create)'),
+        retroId: z.string().optional().describe('Retrospective ID (for create or list filter)'),
+        actionId: z.string().optional().describe('Action item ID (for update)'),
+        status: z
+          .enum(['pending', 'in-progress', 'completed'])
+          .optional()
+          .describe('Status (for update or list filter)'),
+        notes: z.string().optional().describe('Additional notes (for update)'),
+      }).shape,
+    },
+    async ({ action, description, assignee, retroId, actionId, status, notes }) => {
+      const config = await configManager.get();
+
+      if (action === 'create') {
+        if (!description) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: description is required for create action.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const newAction: RetroAction = {
+          id: randomUUID(),
+          description,
+          status: 'pending',
+          assignee,
+          retroId: retroId || '',
+          createdAt: new Date().toISOString(),
+        };
+
+        config.retroActions.push(newAction);
+        await configManager.save(config);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Action item created successfully.\nID: ${newAction.id}\nDescription: ${description}${assignee ? `\nAssignee: ${assignee}` : ''}`,
+            },
+          ],
+        };
+      }
+
+      if (action === 'update') {
+        if (!actionId) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'Error: actionId is required for update action.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const actionItem = config.retroActions.find((a) => a.id === actionId);
+        if (!actionItem) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error: Action item with ID ${actionId} not found.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        if (status) {
+          actionItem.status = status;
+          if (status === 'completed') {
+            actionItem.completedAt = new Date().toISOString();
+          }
+        }
+        if (notes) {
+          actionItem.notes = notes;
+        }
+
+        await configManager.save(config);
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Action item updated successfully.\nStatus: ${actionItem.status}`,
+            },
+          ],
+        };
+      }
+
+      if (action === 'list') {
+        let actions = config.retroActions;
+
+        // Filter by status if provided
+        if (status) {
+          actions = actions.filter((a) => a.status === status);
+        }
+
+        // Filter by retroId if provided
+        if (retroId) {
+          actions = actions.filter((a) => a.retroId === retroId);
+        }
+
+        if (actions.length === 0) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: 'No action items found matching the criteria.',
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(actions, null, 2),
+            },
+          ],
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'Error: Invalid action specified.',
+          },
+        ],
+        isError: true,
+      };
+    },
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -303,3 +303,48 @@ export interface Prince2Organization {
   createdAt: string;
   updatedAt?: string;
 }
+
+// Retrospective and feedback types
+export type RetrospectiveFormat =
+  | 'start-stop-continue'
+  | 'mad-sad-glad'
+  | '4Ls' // Liked, Learned, Lacked, Longed for
+  | 'sailboat'; // Sailboat retrospective
+
+export type FeedbackType = 'positive' | 'negative' | 'suggestion';
+
+export type RetrospectiveStatus = 'active' | 'closed';
+
+export type RetroActionStatus = 'pending' | 'in-progress' | 'completed';
+
+export interface FeedbackItem {
+  id: string;
+  type: FeedbackType;
+  content: string;
+  author?: string; // Optional for anonymous feedback
+  anonymous?: boolean;
+  createdAt: string;
+}
+
+export interface Retrospective {
+  id: string;
+  title: string;
+  format: RetrospectiveFormat;
+  facilitator?: string;
+  participants?: string[];
+  status: RetrospectiveStatus;
+  feedback: FeedbackItem[];
+  createdAt: string;
+  closedAt?: string;
+}
+
+export interface RetroAction {
+  id: string;
+  description: string;
+  status: RetroActionStatus;
+  assignee?: string;
+  retroId: string; // Link to the retrospective
+  createdAt: string;
+  completedAt?: string;
+  notes?: string;
+}

--- a/tests/tools/retrospectiveTools.test.ts
+++ b/tests/tools/retrospectiveTools.test.ts
@@ -1,0 +1,386 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerStartRetrospective } from '../../src/tools/startRetrospective.js';
+import { registerSubmitFeedback } from '../../src/tools/submitFeedback.js';
+import { registerTrackRetroActions } from '../../src/tools/trackRetroActions.js';
+import type { AppConfig } from '../../src/config.js';
+import { configManager } from '../../src/config.js';
+
+// Mock configManager
+vi.mock('../../src/config.js', () => ({
+  configManager: {
+    get: vi.fn(),
+    save: vi.fn(),
+  },
+}));
+
+describe('Retrospective & Feedback Tools', () => {
+  let mockServer: McpServer;
+  let mockConfig: AppConfig;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockServer = { registerTool: vi.fn() } as unknown as McpServer;
+
+    mockConfig = {
+      activeProvider: 'local',
+      providers: [],
+      agileMethodology: { type: 'scrum', settings: {} },
+      sprints: [],
+      kanbanBoards: [],
+      events: [],
+      waterfallPhases: [],
+      valueStreams: [],
+      wasteLog: [],
+      pdcaCycles: [],
+      retrospectives: [],
+      retroActions: [],
+    } as AppConfig;
+
+    (configManager.get as vi.Mock).mockResolvedValue(mockConfig);
+  });
+
+  describe('start_retrospective', () => {
+    it('should register the start_retrospective tool', () => {
+      registerStartRetrospective(mockServer);
+      expect(mockServer.registerTool).toHaveBeenCalledWith(
+        'start_retrospective',
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should start a retrospective session', async () => {
+      registerStartRetrospective(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        title: 'Sprint 10 Retrospective',
+        format: 'start-stop-continue',
+        facilitator: 'Alice',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Retrospective started');
+    });
+
+    it('should support different retrospective formats', async () => {
+      registerStartRetrospective(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const formats = ['start-stop-continue', 'mad-sad-glad', '4Ls', 'sailboat'];
+
+      for (const format of formats) {
+        const result = await handler({
+          title: `Retro with ${format}`,
+          format,
+        });
+        expect(result.isError).toBeUndefined();
+      }
+    });
+
+    it('should include optional participants list', async () => {
+      registerStartRetrospective(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        title: 'Team Retro',
+        format: 'start-stop-continue',
+        facilitator: 'Bob',
+        participants: ['Alice', 'Bob', 'Charlie'],
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.content[0].text).toContain('Retrospective started');
+    });
+  });
+
+  describe('submit_feedback', () => {
+    it('should register the submit_feedback tool', () => {
+      registerSubmitFeedback(mockServer);
+      expect(mockServer.registerTool).toHaveBeenCalledWith(
+        'submit_feedback',
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should submit positive feedback', async () => {
+      mockConfig.retrospectives = [
+        {
+          id: 'retro-123',
+          title: 'Sprint Retro',
+          format: 'start-stop-continue',
+          status: 'active',
+          feedback: [],
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      registerSubmitFeedback(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        retroId: 'retro-123',
+        type: 'positive',
+        content: 'Great teamwork this sprint!',
+        author: 'Alice',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Feedback submitted');
+    });
+
+    it('should submit negative feedback', async () => {
+      mockConfig.retrospectives = [
+        {
+          id: 'retro-123',
+          title: 'Sprint Retro',
+          format: 'mad-sad-glad',
+          status: 'active',
+          feedback: [],
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      registerSubmitFeedback(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        retroId: 'retro-123',
+        type: 'negative',
+        content: 'Too many meetings this sprint',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should submit suggestions', async () => {
+      mockConfig.retrospectives = [
+        {
+          id: 'retro-123',
+          title: 'Sprint Retro',
+          format: 'start-stop-continue',
+          status: 'active',
+          feedback: [],
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      registerSubmitFeedback(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        retroId: 'retro-123',
+        type: 'suggestion',
+        content: 'Let\'s try pair programming next sprint',
+        author: 'Charlie',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should support anonymous feedback', async () => {
+      mockConfig.retrospectives = [
+        {
+          id: 'retro-123',
+          title: 'Sprint Retro',
+          format: 'start-stop-continue',
+          status: 'active',
+          feedback: [],
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      registerSubmitFeedback(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        retroId: 'retro-123',
+        type: 'negative',
+        content: 'Communication could be better',
+        anonymous: true,
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should error if retrospective not found', async () => {
+      registerSubmitFeedback(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        retroId: 'non-existent',
+        type: 'positive',
+        content: 'Test',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('not found');
+    });
+
+    it('should error if retrospective is closed', async () => {
+      mockConfig.retrospectives = [
+        {
+          id: 'retro-123',
+          title: 'Closed Retro',
+          format: 'start-stop-continue',
+          status: 'closed',
+          feedback: [],
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      registerSubmitFeedback(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        retroId: 'retro-123',
+        type: 'positive',
+        content: 'Test',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('closed');
+    });
+  });
+
+  describe('track_retro_actions', () => {
+    it('should register the track_retro_actions tool', () => {
+      registerTrackRetroActions(mockServer);
+      expect(mockServer.registerTool).toHaveBeenCalledWith(
+        'track_retro_actions',
+        expect.any(Object),
+        expect.any(Function),
+      );
+    });
+
+    it('should create a new action item', async () => {
+      registerTrackRetroActions(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        action: 'create',
+        description: 'Implement automated testing for API',
+        assignee: 'Bob',
+        retroId: 'retro-123',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('Action item created');
+    });
+
+    it('should update action item status', async () => {
+      mockConfig.retroActions = [
+        {
+          id: 'action-123',
+          description: 'Test action',
+          status: 'pending',
+          assignee: 'Alice',
+          retroId: 'retro-123',
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      registerTrackRetroActions(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        action: 'update',
+        actionId: 'action-123',
+        status: 'completed',
+      });
+
+      expect(configManager.save).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      expect(result.content[0].text).toContain('updated');
+    });
+
+    it('should list all action items', async () => {
+      mockConfig.retroActions = [
+        {
+          id: 'action-1',
+          description: 'Action 1',
+          status: 'pending',
+          retroId: 'retro-123',
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: 'action-2',
+          description: 'Action 2',
+          status: 'completed',
+          retroId: 'retro-123',
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      registerTrackRetroActions(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        action: 'list',
+      });
+
+      expect(result.content[0].text).toContain('Action 1');
+      expect(result.content[0].text).toContain('Action 2');
+    });
+
+    it('should filter actions by status', async () => {
+      mockConfig.retroActions = [
+        {
+          id: 'action-1',
+          description: 'Pending action',
+          status: 'pending',
+          retroId: 'retro-123',
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: 'action-2',
+          description: 'Completed action',
+          status: 'completed',
+          retroId: 'retro-123',
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      registerTrackRetroActions(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        action: 'list',
+        status: 'pending',
+      });
+
+      expect(result.content[0].text).toContain('Pending action');
+      expect(result.content[0].text).not.toContain('Completed action');
+    });
+
+    it('should filter actions by retroId', async () => {
+      mockConfig.retroActions = [
+        {
+          id: 'action-1',
+          description: 'Action from retro 1',
+          status: 'pending',
+          retroId: 'retro-1',
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: 'action-2',
+          description: 'Action from retro 2',
+          status: 'pending',
+          retroId: 'retro-2',
+          createdAt: new Date().toISOString(),
+        },
+      ];
+      registerTrackRetroActions(mockServer);
+      const handler = (mockServer.registerTool as vi.Mock).mock.calls[0][2];
+
+      const result = await handler({
+        action: 'list',
+        retroId: 'retro-1',
+      });
+
+      expect(result.content[0].text).toContain('Action from retro 1');
+      expect(result.content[0].text).not.toContain('Action from retro 2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements team retrospective and feedback tools for continuous improvement
- Adds three new MCP tools: `start_retrospective`, `submit_feedback`, and `track_retro_actions`
- Includes comprehensive TDD test suite with 17 tests (100% coverage for 2 of 3 tools)

## Changes
- **New Types**: `Retrospective`, `FeedbackItem`, `RetroAction` with full type safety
- **Tool: start_retrospective**: Start retrospective sessions with 4 formats (start-stop-continue, mad-sad-glad, 4Ls, sailboat)
- **Tool: submit_feedback**: Submit positive/negative/suggestion feedback with anonymous option
- **Tool: track_retro_actions**: Create, update, or list action items from retrospectives
- **Config**: Added `retrospectives` and `retroActions` arrays to AppConfig
- **Tests**: Full TDD coverage with validation, anonymous feedback, status filtering

## Test Plan
- [x] All 135 tests pass (17 new retrospective tests)
- [x] TypeScript compilation successful
- [x] Coverage: startRetrospective 100%, submitFeedback 100%, trackRetroActions 83.33%
- [x] Supports 4 retrospective formats
- [x] Anonymous feedback submission
- [x] Action item status tracking (pending, in-progress, completed)
- [x] Filtering actions by status and retroId
- [x] Prevents feedback submission to closed retrospectives

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)